### PR TITLE
CU-1xcxapt Team Roaster Loading Issue fix for main site

### DIFF
--- a/pages/api/members/index.js
+++ b/pages/api/members/index.js
@@ -7,9 +7,12 @@ const BYPASS_AUTH_ORIGINS = ['https://teamwaterloop.ca'];
 module.exports = async (req, res) => {
     await data.initIfNotStarted();
     if (req.method === 'POST') {
-        const authStatus = true;
+        const authStatus = false;
+
         // Get the Access Token from the request headers
-        if(!BYPASS_AUTH_ORIGINS.includes(req.headers['origin'])) {
+        if(BYPASS_AUTH_ORIGINS.includes(req.headers['origin'])) {
+            authStatus = true;
+        } else {
             const token = cookie.parse(req.headers.cookie).token;
             authStatus = await data.auth.checkAnyUser(`Bearer ${token}`, res);
         }

--- a/pages/api/members/index.js
+++ b/pages/api/members/index.js
@@ -7,10 +7,12 @@ const BYPASS_AUTH_ORIGINS = ['https://teamwaterloop.ca'];
 module.exports = async (req, res) => {
     await data.initIfNotStarted();
     if (req.method === 'POST') {
+        const authStatus = true;
         // Get the Access Token from the request headers
-        const token = cookie.parse(req.headers.cookie).token;
-        const authStatus = BYPASS_AUTH_ORIGINS.includes(req.headers['origin']) 
-                            || await data.auth.checkAnyUser(`Bearer ${token}`, res);
+        if(!BYPASS_AUTH_ORIGINS.includes(req.headers['origin'])) {
+            const token = cookie.parse(req.headers.cookie).token;
+            authStatus = await data.auth.checkAnyUser(`Bearer ${token}`, res);
+        }
                             
         if (authStatus) {
             res.setHeader('Content-Type', 'application/json');

--- a/pages/api/members/index.js
+++ b/pages/api/members/index.js
@@ -7,7 +7,7 @@ const BYPASS_AUTH_ORIGINS = ['https://teamwaterloop.ca'];
 module.exports = async (req, res) => {
     await data.initIfNotStarted();
     if (req.method === 'POST') {
-        const authStatus = false;
+        let authStatus = false;
 
         // Get the Access Token from the request headers
         if(BYPASS_AUTH_ORIGINS.includes(req.headers['origin'])) {


### PR DESCRIPTION
The TeamHub endpoint "/api/members" was returning a 500 server error when the API is called outside of the TeamHub site (i.e. without being authenticated). 

This was due to an invalid cookie parsing that should only be performed when the user is authenticated, however, the current approach performs the parsing even when the endpoint is called externally without logging in.

So to fix this, I included a condition to only get the cookies when the "origin" header is not included.